### PR TITLE
support for running whole stack inside docker using docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.venv*
+node_modules
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7.7
+
+# Install requirements first, so we can skip unless the file changes
+COPY requirements.txt /requirements.txt
+RUN pip install -r /requirements.txt
+
+# Copy code to /src and run from there
+ADD . /src
+WORKDIR /src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+web:
+  build: .
+  command: python -m bottle --bind 0.0.0.0:8080 --reload lib.server
+  ports:
+    - "8080:8080"
+  links:
+    - mongo
+    - redis
+  volumes:
+    - ./:/src
+  environment:
+    - MONGODB_HOSTS=mongo
+    - REDIS_HOST=redis
+    - PORT=8080
+
+worker:
+  build: .
+  command: python -u lib/worker.py
+  links:
+    - mongo
+    - redis
+  volumes:
+    - ./:/src
+  environment:
+    - PYTHONPATH=/src
+    - MONGODB_HOSTS=mongo
+    - REDIS_HOST=redis
+
+mongo:
+  image: mongo:2.6
+  log_driver: none
+
+redis:
+  image: redis:2.8
+  log_driver: none

--- a/lib/mongo.py
+++ b/lib/mongo.py
@@ -8,16 +8,22 @@ __mongo = None
 
 
 def __init_connection():
+    # comma-separated list of host[:port]
+    hosts = os.environ.get('MONGODB_HOSTS', 'localhost')
+    replica_set = os.environ.get('MONGODB_REPLICA_SET')
     username = os.environ.get('MONGODB_USERNAME')
     password = os.environ.get('MONGODB_PASSWORD')
 
     if username and password:
-        url = 'mongodb://%s:%s@candidate.48.mongolayer.com:10146,candidate.11.mongolayer.com:10639/%s' % (
-            username, password, MONGODB_DATABASE
+        url = 'mongodb://{username}:{password}@{hosts}/{db}'.format(
+            hosts=hosts,
+            username=username,
+            password=password,
+            db=MONGODB_DATABASE,
         )
-        client = MongoReplicaSetClient(url, replicaSet='set-54def1ba0a1d8017550006f3')
+        client = MongoReplicaSetClient(url, replicaSet=replica_set)
     else:
-        client = MongoClient('localhost')
+        client = MongoClient(hosts)
 
     return client[MONGODB_DATABASE]
 


### PR DESCRIPTION
- use `docker-compose up` to run everything
- also adds required env var MONGODB_HOSTS and MONGODB_REPLICA_SET to allow configuration
